### PR TITLE
use custom toolchains for travis-ci

### DIFF
--- a/docker/ubuntu/kocervantes/Dockerfile
+++ b/docker/ubuntu/kocervantes/Dockerfile
@@ -5,3 +5,5 @@ USER ko
 WORKDIR /home/ko
 ADD ./build_cervantes_tc.sh /home/ko/build_cervantes_tc.sh
 RUN ./build_cervantes_tc.sh
+
+RUN echo "export PATH=/home/ko/x-tools/arm-cervantes-linux-gnueabi/bin:\$PATH" >> /home/ko/.bashrc

--- a/docker/ubuntu/kokindle/Dockerfile
+++ b/docker/ubuntu/kokindle/Dockerfile
@@ -5,3 +5,7 @@ USER ko
 WORKDIR /home/ko
 ADD ./build_kindle_tc.sh /home/ko/build_kindle_tc.sh
 RUN ./build_kindle_tc.sh
+
+RUN echo "export PATH=/home/ko/x-tools/arm-kindle-linux-gnueabi/bin:\$PATH" >> /home/ko/.bashrc
+RUN echo "export PATH=/home/ko/x-tools/arm-kindle5-linux-gnueabi/bin:\$PATH" >> /home/ko/.bashrc
+RUN echo "export PATH=/home/ko/x-tools/arm-kindlepw2-linux-gnueabi/bin:\$PATH" >> /home/ko/.bashrc

--- a/docker/ubuntu/kokobo/Dockerfile
+++ b/docker/ubuntu/kokobo/Dockerfile
@@ -5,3 +5,5 @@ USER ko
 WORKDIR /home/ko
 ADD ./build_kobo_tc.sh /home/ko/build_kobo_tc.sh
 RUN ./build_kobo_tc.sh
+
+RUN echo "export PATH=/home/ko/x-tools/arm-kobo-linux-gnueabihf/bin:\$PATH" >> /home/ko/.bashrc


### PR DESCRIPTION
on pocketbook we download the sdk and then [export the path](https://github.com/koreader/virdevenv/blob/master/docker/ubuntu/kopb/Dockerfile#L8).

for kindles, kobos and cervantes we build koxtoolchain but actually don't use it. (I see in the logs calls to arm-linux-gnueabi / arm-linux-gnueabihf, which implies that our custom toolchains were not found on PATH.

For example, for kobos the toolchain check in koreader-base is [here](https://github.com/koreader/koreader-base/blob/master/Makefile.defs#L61-L66)

