### PR TITLE
[fix, Docker] baseimage-python user

### DIFF
--- a/docker/ubuntu/baseimage-python/Dockerfile
+++ b/docker/ubuntu/baseimage-python/Dockerfile
@@ -5,3 +5,5 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends python
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+USER ko

--- a/docker/ubuntu/baseimage-python/Makefile
+++ b/docker/ubuntu/baseimage-python/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.0
+VERSION=0.1.1
 
 all: build
 


### PR DESCRIPTION
Same as 9491e97702455313aa25062047b67dcc6b94651e

Results in `pthread_create() failed, 1 EPERM` error, indicating the baseimage-python image accidentally ran as root.