### PR TITLE
[Docker] kopb: slim down a bit by removing .git and locales

### DIFF
--- a/docker/ubuntu/kopb/Dockerfile
+++ b/docker/ubuntu/kopb/Dockerfile
@@ -1,8 +1,13 @@
-FROM frenzie/kobase-python:0.1.0
+FROM frenzie/kobase-python:0.1.1
 
 ENV DEBIAN_FRONTEND noninteractive
 
 USER ko
 WORKDIR /home/ko
-RUN git clone https://github.com/pocketbook-free/SDK_481 pocketbook-toolchain
-RUN echo "export PATH=/home/ko/pocketbook-toolchain/bin:\$PATH" >>/home/ko/.bashrc
+RUN git clone https://github.com/pocketbook-free/SDK_481 pocketbook-toolchain && \
+    cd pocketbook-toolchain && \
+    rm -rf .git/ && \
+    rm -rf arm-obreey-linux-gnueabi/sysroot/usr/lib/locale/
+RUN echo "export PATH=/home/ko/pocketbook-toolchain/bin:\$PATH" >>/home/ko/.bashrc && \
+    echo "export POCKETBOOK_TOOLCHAIN=/home/ko/pocketbook-toolchain" >>/home/ko/.bashrc && \
+    echo "export SYSROOT=/home/ko/pocketbook-toolchain/arm-obreey-linux-gnueabi/sysroot" >>/home/ko/.bashrc

--- a/docker/ubuntu/kopb/Makefile
+++ b/docker/ubuntu/kopb/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.0
+VERSION=0.1.1
 
 all: build
 


### PR DESCRIPTION
Cf. https://github.com/koreader/koreader-base/pull/765 because the
entire toolchain wasn't even actually being used! D-:

Still needs adjustments in kodev in front.