### PR TITLE
Docker baseimage: add custom xgettext build

### DIFF
--- a/docker/ubuntu/baseimage-python/Dockerfile
+++ b/docker/ubuntu/baseimage-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM koreader/kobase:0.1.3
+FROM koreader/kobase:0.1.4
 
 USER root
 RUN apt-get update \

--- a/docker/ubuntu/baseimage-python/Makefile
+++ b/docker/ubuntu/baseimage-python/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.3
+VERSION=0.1.4
 
 all: build
 

--- a/docker/ubuntu/baseimage/Makefile
+++ b/docker/ubuntu/baseimage/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.3
+VERSION=0.1.4
 
 all: build
 

--- a/docker/ubuntu/baseimage/bootstrap.sh
+++ b/docker/ubuntu/baseimage/bootstrap.sh
@@ -36,3 +36,19 @@ apt-get install -y \
 
 # --upgrade to prevent urllib3 errors
 pip3 install transifex-client --upgrade
+
+# compile custom xgettext with newline patch, cf. https://github.com/koreader/koreader/pull/5238#issuecomment-523794831
+# upstream bug https://savannah.gnu.org/bugs/index.php?56794
+GETTEXT_VER=0.20.1
+wget http://ftpmirror.gnu.org/gettext/gettext-${GETTEXT_VER}.tar.gz
+tar -xf gettext-${GETTEXT_VER}.tar.gz
+pushd gettext-${GETTEXT_VER} && {
+    wget -O ignore-first-newline-of-Lua-multiline-string.patch https://savannah.gnu.org/bugs/download.php?file_id=47379
+    patch -p1 < ignore-first-newline-of-Lua-multiline-string.patch
+    ./configure
+    make -j$(nproc)
+    make install
+    ldconfig
+} && popd
+rm gettext-${GETTEXT_VER}.tar.gz
+rm -rf gettext-${GETTEXT_VER}

--- a/docker/ubuntu/baseimage/bootstrap.sh
+++ b/docker/ubuntu/baseimage/bootstrap.sh
@@ -43,10 +43,10 @@ GETTEXT_VER=0.20.1
 wget http://ftpmirror.gnu.org/gettext/gettext-${GETTEXT_VER}.tar.gz
 tar -xf gettext-${GETTEXT_VER}.tar.gz
 pushd gettext-${GETTEXT_VER} && {
-    wget -O ignore-first-newline-of-Lua-multiline-string.patch https://savannah.gnu.org/bugs/download.php?file_id=47379
-    patch -p1 < ignore-first-newline-of-Lua-multiline-string.patch
+    wget -O ignore-first-newline-of-lua-multiline-string.patch https://savannah.gnu.org/bugs/download.php?file_id=47379
+    patch -p1 <ignore-first-newline-of-lua-multiline-string.patch
     ./configure
-    make -j$(nproc)
+    make -j"$(nproc)"
     make install
     ldconfig
 } && popd

--- a/docker/ubuntu/koappimage/Dockerfile
+++ b/docker/ubuntu/koappimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM koreader/kobase-python:0.1.3
+FROM koreader/kobase-python:0.1.4
 
 USER root
 RUN apt-get update && \

--- a/docker/ubuntu/koappimage/Makefile
+++ b/docker/ubuntu/koappimage/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.5
+VERSION=0.1.6
 
 all: build
 


### PR DESCRIPTION
See https://github.com/koreader/koreader/pull/5238#issuecomment-523675211

Even if a fix is implemented upstream soon, it'd be years before we could use a precompiled binary anyway.