### PR TITLE
Docker/baseimage-clang: Update to Clang 9

### DIFF
--- a/docker/ubuntu/baseimage-clang/Dockerfile
+++ b/docker/ubuntu/baseimage-clang/Dockerfile
@@ -1,17 +1,17 @@
-FROM koreader/kobase:0.1.3
+FROM koreader/kobase:0.1.4
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
-COPY clang8.list /etc/apt/sources.list.d/clang8.list
+COPY clang9.list /etc/apt/sources.list.d/clang9.list
 RUN apt-get remove gcc -y \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
-    && apt-get install -y --no-install-recommends clang-8 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 380 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 380 \
-    && update-alternatives --install /usr/bin/clang-cpp clang-cpp /usr/bin/clang-cpp-8 380 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-8 380 \
+    && apt-get install -y --no-install-recommends clang-9 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 380 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 380 \
+    && update-alternatives --install /usr/bin/clang-cpp clang-cpp /usr/bin/clang-cpp-9 380 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-9 380 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/ubuntu/baseimage-clang/Makefile
+++ b/docker/ubuntu/baseimage-clang/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.2
+VERSION=0.1.3
 
 all: build
 

--- a/docker/ubuntu/baseimage-clang/clang8.list
+++ b/docker/ubuntu/baseimage-clang/clang8.list
@@ -1,2 +1,0 @@
-deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main
-deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main

--- a/docker/ubuntu/baseimage-clang/clang9.list
+++ b/docker/ubuntu/baseimage-clang/clang9.list
@@ -1,0 +1,2 @@
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main
+deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main


### PR DESCRIPTION
Release notes: <http://releases.llvm.org/9.0.0/tools/clang/docs/ReleaseNotes.html>


**DON'T MERGE UNTIL THE POINT RELEASE IS OUT** (and also out on `deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main`)

Clang 9 compiler-rt is broken, see https://reviews.llvm.org/D67628

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/45)
<!-- Reviewable:end -->
