### PR TITLE
Use our own PocketBook TC instead of ancient gcc 4.8

### DIFF
--- a/docker/ubuntu/kopb/Dockerfile
+++ b/docker/ubuntu/kopb/Dockerfile
@@ -1,13 +1,7 @@
-FROM koreader/kobase-python:0.1.5
-
-ENV DEBIAN_FRONTEND noninteractive
+FROM koreader/kobase:0.1.6
 
 USER ko
+
 WORKDIR /home/ko
-RUN git clone https://github.com/pocketbook-free/SDK_481 pocketbook-toolchain
-WORKDIR /home/ko/pocketbook-toolchain
-RUN rm -rf .git/ && \
-    rm -rf arm-obreey-linux-gnueabi/sysroot/usr/lib/locale/
-RUN echo "export PATH=/home/ko/pocketbook-toolchain/bin:\$PATH" >>/home/ko/.bashrc && \
-    echo "export POCKETBOOK_TOOLCHAIN=/home/ko/pocketbook-toolchain" >>/home/ko/.bashrc && \
-    echo "export SYSROOT=/home/ko/pocketbook-toolchain/arm-obreey-linux-gnueabi/sysroot" >>/home/ko/.bashrc
+COPY ./build_pb_tc.sh /home/ko/build_pb_tc.sh
+RUN ./build_pb_tc.sh

--- a/docker/ubuntu/kopb/Makefile
+++ b/docker/ubuntu/kopb/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.3
+VERSION=0.2.0
 
 all: build
 

--- a/docker/ubuntu/kopb/build_pb_tc.sh
+++ b/docker/ubuntu/kopb/build_pb_tc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Building toolchain for PocketBook..."
+git clone https://github.com/koreader/koxtoolchain.git
+pushd koxtoolchain && {
+    # obviously change this before merging
+    git fetch origin pull/22/head
+    git checkout FETCH_HEAD
+
+    ./gen-tc.sh pocketbook
+} && popd || exit
+
+rm -rf koxtoolchain

--- a/docker/ubuntu/kopb/build_pb_tc.sh
+++ b/docker/ubuntu/kopb/build_pb_tc.sh
@@ -3,9 +3,7 @@
 echo "Building toolchain for PocketBook..."
 git clone https://github.com/koreader/koxtoolchain.git
 pushd koxtoolchain && {
-    # obviously change this before merging
-    git fetch origin pull/22/head
-    git checkout FETCH_HEAD
+    git checkout 711acc41e2582c63873c4f1a29696cfb6f1a247a
 
     ./gen-tc.sh pocketbook
 } && popd || exit


### PR DESCRIPTION
See <https://github.com/koreader/koxtoolchain/pull/22>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/49)
<!-- Reviewable:end -->
