### PR TITLE
[fix] Docker baseimage: add libc6-dev:i386

### DIFF
--- a/docker/ubuntu/baseimage-clang/Dockerfile
+++ b/docker/ubuntu/baseimage-clang/Dockerfile
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 COPY clang12.list /etc/apt/sources.list.d/clang12.list
-RUN apt-get remove gcc -y \
+RUN apt-get remove gcc gcc-8 -y \
     && wget --progress=dot:giga -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get install -y --no-install-recommends clang-12 \

--- a/docker/ubuntu/baseimage/bootstrap.sh
+++ b/docker/ubuntu/baseimage/bootstrap.sh
@@ -7,12 +7,13 @@ dpkg --add-architecture i386
 apt-get update
 apt-get upgrade -y
 
-ARM_SF_TC=(gcc-arm-linux-gnueabi g++-arm-linux-gnueabi)
-ARM_HF_TC=(gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf)
-ARM64_TC=(gcc-aarch64-linux-gnu g++-aarch64-linux-gnu)
+ARM_SF_TC=(gcc-8-arm-linux-gnueabi g++-8-arm-linux-gnueabi)
+ARM_HF_TC=(gcc-8-arm-linux-gnueabihf g++-8-arm-linux-gnueabihf)
+ARM64_TC=(gcc-8-aarch64-linux-gnu g++-8-aarch64-linux-gnu)
 TC_BUILD_DEPS=(gperf help2man bison texinfo flex gawk libncurses5-dev)
-LIB32_GCC_DEV=(lib32gcc-7-dev libx32gcc1 libx32gomp1 libx32itm1
-    libx32atomic1 libx32asan0 libx32quadmath0 libc6-x32)
+LIB32_GCC_DEV=(lib32gcc-8-dev libx32gcc1 libx32gomp1 libx32itm1
+    libx32atomic1 libx32asan0 libx32quadmath0 libc6-x32
+    libc6-dev:i386)
 # libtool-bin is due to a libzmq issue, see https://github.com/zeromq/libzmq/pull/1497
 # can be removed if libzmq is bumped
 MISC_TOOLS=(git subversion zip unzip vim wget p7zip-full bash-completion
@@ -26,10 +27,10 @@ echo "| installing dependencies..."
 echo "| ${LUAJIT_DEPS[*]} "
 echo " ------------------------------------------"
 
-apt-get install -y \
+apt-get install --no-install-recommends -y \
     "${MISC_TOOLS[@]}" \
-    build-essential dpkg-dev pkg-config python3-pip \
-    gcc-7 cpp-7 g++-7 make automake cmake ccache \
+    build-essential dpkg-dev pkg-config \
+    gcc-8 cpp-8 g++-8 make automake cmake ccache \
     lua5.1 \
     ninja-build \
     patch libtool nasm autoconf2.64 \
@@ -38,6 +39,9 @@ apt-get install -y \
     $HARFBUZZ_DEPS \
     "${ARM_SF_TC[@]}" "${ARM_HF_TC[@]}" "${ARM64_TC[@]}" \
     "${LUAJIT_DEPS[@]}"
+
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
 # compile custom xgettext with newline patch, cf. https://github.com/koreader/koreader/pull/5238#issuecomment-523794831
 # upstream bug https://savannah.gnu.org/bugs/index.php?56794

--- a/docker/ubuntu/koandroid/fetch_android_tc.sh
+++ b/docker/ubuntu/koandroid/fetch_android_tc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -e
 
 echo "Downloading NDK..."
-rm Makefile
 wget https://raw.githubusercontent.com/koreader/koreader-base/d21a0b680832c911675daf035130a0e190e5d386/toolchain/Makefile
 echo -e "y" | make android-ndk android-sdk
 rm Makefile


### PR DESCRIPTION
An oversight for LuaJIT cross-compilation on newer systems.

Also swap in GCC 8 instead of 7 since apparently that's an easy option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/63)
<!-- Reviewable:end -->
