### PR TITLE
Docker koandroid: purposefully install openjdk-8-jre-headless as ant dependency

### DIFF
--- a/docker/ubuntu/koandroid/Dockerfile
+++ b/docker/ubuntu/koandroid/Dockerfile
@@ -2,7 +2,7 @@ FROM koreader/kobase-python:0.2.0
 
 USER root
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk ant && \
+    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-8-jre-headless ant && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/ubuntu/koandroid/Dockerfile
+++ b/docker/ubuntu/koandroid/Dockerfile
@@ -2,7 +2,7 @@ FROM koreader/kobase-python:0.2.0
 
 USER root
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-8-jre-headless ant && \
+    apt-get install -y --no-install-recommends openjdk-8-jdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Otherwise ant pulls in default-jre-headless which is openjdk-11-jre-headless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/65)
<!-- Reviewable:end -->
