### PR TITLE
Allow install scripts to be used by koreader CI

### DIFF
--- a/docker/ubuntu/baseimage/Dockerfile
+++ b/docker/ubuntu/baseimage/Dockerfile
@@ -17,4 +17,4 @@ RUN chown ko:ko /home/ko/.bashrc
 USER ko
 WORKDIR /home/ko
 RUN ./install_lint.sh
-RUN ./install_luarocks.sh
+RUN ./install_luarocks.sh "/home/ko"

--- a/docker/ubuntu/baseimage/install_lint.sh
+++ b/docker/ubuntu/baseimage/install_lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-HOME=/home/ko
+HOME="$1"
 
 cd $HOME || exit
 
@@ -9,15 +9,15 @@ export PATH=${HOME}/local/bin:$PATH
 [ ! -d "${HOME}/local/bin" ] && mkdir -p "${HOME}/local/bin"
 
 #install our own updated shellcheck
-SHELLCHECK_VERSION="v0.7.2"
+SHELLCHECK_VERSION="v0.8.0"
 SHELLCHECK_URL="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz"
-if ! command -v shellcheck; then
+if [ "$(shellcheck --version)" != "v0.8.0" ]; then
     curl -sSL "${SHELLCHECK_URL}" | tar --exclude 'SHA256SUMS' --strip-components=1 -C "${HOME}/local/bin" -xJf -
     chmod +x "${HOME}/local/bin/shellcheck"
-    shellcheck --version
 else
     echo -e "${ANSI_GREEN}Using system shellcheck."
 fi
+shellcheck --version
 
 # install shfmt
 SHFMT_URL="https://github.com/mvdan/sh/releases/download/v3.4.0/shfmt_v3.4.0_linux_amd64"

--- a/docker/ubuntu/baseimage/install_luarocks.sh
+++ b/docker/ubuntu/baseimage/install_luarocks.sh
@@ -1,30 +1,11 @@
 #!/usr/bin/env bash
 
-HOME=/home/ko
+apt-get install --no-install-recommends luarocks
 
-cd $HOME || exit
+luarocks install luacov
+luarocks install ldoc
 
-git clone https://github.com/torch/luajit-rocks.git
-pushd luajit-rocks && {
-    git checkout 2c7496b905f6f972673effda4884766433b7583b
-    cmake . -DWITH_LUAJIT21=ON -DCMAKE_INSTALL_PREFIX=${HOME}/local
-    make install
-} && popd || exit
-rm -rf luajit-rocks
+luarocks install lanes # for parallel luacheck
+luarocks install luacheck
 
-mkdir ${HOME}/.luarocks
-cp ${HOME}/local/etc/luarocks/config.lua ${HOME}/.luarocks/config.lua
-
-export PATH=$HOME/local/bin:$PATH
-
-echo "wrap_bin_scripts = false" >>${HOME}/.luarocks/config.lua
-luarocks --local install luafilesystem
-luarocks --local install ansicolors
-luarocks --local install busted 2.0.0-1
-luarocks --local install luacov
-# luasec doesn't automatically detect 64-bit libs
-luarocks --local install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu
-luarocks --local install luacov-coveralls --server=http://rocks.moonscript.org/dev
-luarocks --local install luacheck
-luarocks --local install lanes # for parallel luacheck
-luarocks --local install ldoc
+luarocks build https://raw.githubusercontent.com/Olivine-Labs/busted/2e4799e06b865c352baa7f7721e32aedaafd19d6/busted-scm-2.rockspec


### PR DESCRIPTION
This is part of work to also use Github actions as CI

Use distro luarocks
Install packages globally
Use latest busted
Dont install luacov-coveralls & luasec: we don't use them at all
There is no need to explicitly install luarocks dependencies

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/71)
<!-- Reviewable:end -->
