### PR TITLE
Add REGISTRY variable for different Docker registries

### DIFF
--- a/docker/ubuntu/baseimage-18.04/Dockerfile
+++ b/docker/ubuntu/baseimage-18.04/Dockerfile
@@ -1,4 +1,5 @@
-FROM phusion/baseimage:bionic-1.0.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/phusion/baseimage:bionic-1.0.0
 
 COPY ./bootstrap.sh /bootstrap.sh
 RUN /bootstrap.sh && \

--- a/docker/ubuntu/baseimage-18.04/Makefile
+++ b/docker/ubuntu/baseimage-18.04/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.3.0
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile bootstrap.sh
-	docker build --rm=true -t $(REGISTRY)$(USER)/kobase-18.04:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kobase-18.04:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase-18.04:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kobase-18.04:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kobase-18.04:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kobase-18.04:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/baseimage-18.04/Makefile
+++ b/docker/ubuntu/baseimage-18.04/Makefile
@@ -3,12 +3,12 @@ VERSION=0.3.0
 all: build
 
 build: Dockerfile bootstrap.sh
-	docker build --rm=true -t $(USER)/kobase-18.04:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kobase-18.04:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kobase-18.04:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase-18.04:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kobase-18.04:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kobase-18.04:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -1,4 +1,5 @@
-FROM phusion/baseimage:focal-1.2.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/phusion/baseimage:focal-1.2.0
 
 COPY ./bootstrap.sh /bootstrap.sh
 RUN /bootstrap.sh && \

--- a/docker/ubuntu/baseimage-20.04/Makefile
+++ b/docker/ubuntu/baseimage-20.04/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.3.0
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile bootstrap.sh
-	docker build --rm=true -t $(REGISTRY)$(USER)/kobase:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kobase:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kobase:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kobase:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kobase:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/baseimage-20.04/Makefile
+++ b/docker/ubuntu/baseimage-20.04/Makefile
@@ -3,12 +3,12 @@ VERSION=0.3.0
 all: build
 
 build: Dockerfile bootstrap.sh
-	docker build --rm=true -t $(USER)/kobase:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kobase:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kobase:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kobase:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kobase:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/baseimage-clang/Dockerfile
+++ b/docker/ubuntu/baseimage-clang/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase:0.3.0
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/docker/ubuntu/baseimage-clang/Makefile
+++ b/docker/ubuntu/baseimage-clang/Makefile
@@ -3,12 +3,12 @@ VERSION=0.3.0
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kobase-clang:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kobase-clang:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kobase-clang:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase-clang:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kobase-clang:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kobase-clang:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/baseimage-clang/Makefile
+++ b/docker/ubuntu/baseimage-clang/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.3.0
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kobase-clang:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kobase-clang:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase-clang:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kobase-clang:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kobase-clang:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kobase-clang:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/baseimage-python/Dockerfile
+++ b/docker/ubuntu/baseimage-python/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase:0.2.2
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase:0.2.2
 
 USER root
 RUN apt-get update \

--- a/docker/ubuntu/baseimage-python/Makefile
+++ b/docker/ubuntu/baseimage-python/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.2.2
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kobase-python:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kobase-python:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase-python:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kobase-python:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kobase-python:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kobase-python:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/baseimage-python/Makefile
+++ b/docker/ubuntu/baseimage-python/Makefile
@@ -3,12 +3,12 @@ VERSION=0.2.2
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kobase-python:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kobase-python:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kobase-python:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobase-python:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kobase-python:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kobase-python:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/koandroid/Dockerfile
+++ b/docker/ubuntu/koandroid/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER root
 RUN apt-get update && \

--- a/docker/ubuntu/koandroid/Makefile
+++ b/docker/ubuntu/koandroid/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.5.3
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/koandroid:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/koandroid:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/koandroid:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/koandroid:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/koandroid:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/koandroid:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/koandroid/Makefile
+++ b/docker/ubuntu/koandroid/Makefile
@@ -3,12 +3,12 @@ VERSION=0.5.3
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/koandroid:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/koandroid:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/koandroid:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/koandroid:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/koandroid:$(VERSION)
+	docker push $(REGISTRY)$(USER)/koandroid:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/koappimage/Dockerfile
+++ b/docker/ubuntu/koappimage/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER root
 RUN apt-get update && \

--- a/docker/ubuntu/koappimage/Makefile
+++ b/docker/ubuntu/koappimage/Makefile
@@ -3,12 +3,12 @@ VERSION=0.3.0
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/koappimage:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/koappimage:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/koappimage:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/koappimage:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/koappimage:$(VERSION)
+	docker push $(REGISTRY)$(USER)/koappimage:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/koappimage/Makefile
+++ b/docker/ubuntu/koappimage/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.3.0
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/koappimage:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/koappimage:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/koappimage:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/koappimage:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/koappimage:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/koappimage:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kobookeen/Dockerfile
+++ b/docker/ubuntu/kobookeen/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER ko
 

--- a/docker/ubuntu/kobookeen/Makefile
+++ b/docker/ubuntu/kobookeen/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.2.3
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kobookeen:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kobookeen:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobookeen:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kobookeen:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kobookeen:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kobookeen:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kobookeen/Makefile
+++ b/docker/ubuntu/kobookeen/Makefile
@@ -3,12 +3,12 @@ VERSION=0.2.3
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kobookeen:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kobookeen:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kobookeen:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kobookeen:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kobookeen:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kobookeen:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kocervantes/Dockerfile
+++ b/docker/ubuntu/kocervantes/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER ko
 

--- a/docker/ubuntu/kocervantes/Makefile
+++ b/docker/ubuntu/kocervantes/Makefile
@@ -3,12 +3,12 @@ VERSION=0.2.3
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kocervantes:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kocervantes:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kocervantes:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kocervantes:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kocervantes:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kocervantes:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kocervantes/Makefile
+++ b/docker/ubuntu/kocervantes/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.2.3
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kocervantes:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kocervantes:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kocervantes:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kocervantes:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kocervantes:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kocervantes:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kokindle/Dockerfile
+++ b/docker/ubuntu/kokindle/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER ko
 

--- a/docker/ubuntu/kokindle/Makefile
+++ b/docker/ubuntu/kokindle/Makefile
@@ -3,12 +3,12 @@ VERSION=0.2.3
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kokindle:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kokindle:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kokindle:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kokindle:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kokindle:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kokindle:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kokindle/Makefile
+++ b/docker/ubuntu/kokindle/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.2.3
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kokindle:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kokindle:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kokindle:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kokindle:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kokindle:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kokindle:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kokobo/Dockerfile
+++ b/docker/ubuntu/kokobo/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER ko
 

--- a/docker/ubuntu/kokobo/Makefile
+++ b/docker/ubuntu/kokobo/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.2.3
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kokobo:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kokobo:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kokobo:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kokobo:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kokobo:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kokobo:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kokobo/Makefile
+++ b/docker/ubuntu/kokobo/Makefile
@@ -3,12 +3,12 @@ VERSION=0.2.3
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kokobo:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kokobo:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kokobo:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kokobo:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kokobo:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kokobo:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kopb/Dockerfile
+++ b/docker/ubuntu/kopb/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER ko
 

--- a/docker/ubuntu/kopb/Makefile
+++ b/docker/ubuntu/kopb/Makefile
@@ -3,12 +3,12 @@ VERSION=0.3.3
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kopb:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kopb:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kopb:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kopb:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kopb:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kopb:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kopb/Makefile
+++ b/docker/ubuntu/kopb/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.3.3
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kopb:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kopb:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kopb:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kopb:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kopb:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kopb:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/koremarkable/Dockerfile
+++ b/docker/ubuntu/koremarkable/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase-18.04:0.3.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER ko
 

--- a/docker/ubuntu/koremarkable/Makefile
+++ b/docker/ubuntu/koremarkable/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.2.3
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/koremarkable:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/koremarkable:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/koremarkable:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/koremarkable:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/koremarkable:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/koremarkable:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/koremarkable/Makefile
+++ b/docker/ubuntu/koremarkable/Makefile
@@ -3,12 +3,12 @@ VERSION=0.2.3
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/koremarkable:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/koremarkable:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/koremarkable:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/koremarkable:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/koremarkable:$(VERSION)
+	docker push $(REGISTRY)$(USER)/koremarkable:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kout/Dockerfile
+++ b/docker/ubuntu/kout/Dockerfile
@@ -1,4 +1,5 @@
-FROM koreader/kobase:0.2.0
+ARG REGISTRY=docker.io
+FROM $REGISTRY/koreader/kobase:0.2.0
 
 USER root
 RUN add-apt-repository ppa:bhdouglass/clickable \

--- a/docker/ubuntu/kout/Makefile
+++ b/docker/ubuntu/kout/Makefile
@@ -3,12 +3,12 @@ VERSION=0.2.0
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(USER)/kout:$(VERSION) .
+	docker build --rm=true -t $(REGISTRY)$(USER)/kout:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(USER)/kout:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kout:$(VERSION) bash -l
 
 push:
-	docker push $(USER)/kout:$(VERSION)
+	docker push $(REGISTRY)$(USER)/kout:$(VERSION)
 
 .PHONY: all clean test push shell

--- a/docker/ubuntu/kout/Makefile
+++ b/docker/ubuntu/kout/Makefile
@@ -1,14 +1,15 @@
 VERSION=0.2.0
+REGISTRY?=docker.io
 
 all: build
 
 build: Dockerfile
-	docker build --rm=true -t $(REGISTRY)$(USER)/kout:$(VERSION) .
+	docker build --build-arg REGISTRY=$(REGISTRY) --rm=true -t $(REGISTRY)/$(USER)/kout:$(VERSION) .
 
 shell:
-	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)$(USER)/kout:$(VERSION) bash -l
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i $(REGISTRY)/$(USER)/kout:$(VERSION) bash -l
 
 push:
-	docker push $(REGISTRY)$(USER)/kout:$(VERSION)
+	docker push $(REGISTRY)/$(USER)/kout:$(VERSION)
 
 .PHONY: all clean test push shell


### PR DESCRIPTION
Basic usage would look like:

```
USER=koreader REGISTRY=ghcr.io make build
USER=koreader REGISTRY=ghcr.io make push
```

With as a result:
https://github.com/orgs/koreader/packages
https://github.com/orgs/koreader/packages/container/package/kobase-clang

<img src=https://user-images.githubusercontent.com/202757/229374661-64ef07cd-78a9-4e13-9592-eef62bd771e3.png width=50%>

To be made public it would need to be associated with a repository.

For some background as to why I'm adding this:
https://news.ycombinator.com/item?id=35154025 (tl;dr Docker announced they would get rid of the free registry)
https://www.docker.com/developers/free-team-faq/ (tl;dr Docker reversed its plans a couple weeks later)

<hr>

Note that Google made a tool called `crane` that is supposed to be able to move images over between registries, so the main point of this PR may be little more than making it easier to decide where to push it first.
https://blog.alexellis.io/docker-is-deleting-open-source-images/

```
crane cp docker.io/openfaas/gateway:0.26.3 ghcr.io/openfaas/gateway:0.26.3
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/81)
<!-- Reviewable:end -->
