### PR TITLE
android: update to use NDK 23c

### DIFF
--- a/docker/ubuntu/koandroid/Dockerfile
+++ b/docker/ubuntu/koandroid/Dockerfile
@@ -3,7 +3,7 @@ FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER root
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk-headless && \
+    apt-get install -y --no-install-recommends hardlink openjdk-8-jdk-headless && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/ubuntu/koandroid/Dockerfile
+++ b/docker/ubuntu/koandroid/Dockerfile
@@ -3,7 +3,7 @@ FROM $REGISTRY/koreader/kobase-18.04:0.3.0
 
 USER root
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk && \
+    apt-get install -y --no-install-recommends openjdk-8-jdk-headless && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/ubuntu/koandroid/build_android_tc.sh
+++ b/docker/ubuntu/koandroid/build_android_tc.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 
-echo "Pruning NDK to reduce image size..."
-NDK=android-ndk-r15c
-# only keep platform-14 (32bit ABIs) and platform-21 (64bit ABIs)
-rm -rf ${NDK}/platforms/android-{9,12,13,15,16,17,18,19,22,23,24,26}
-# remove obsolete android ABIs
-rm -rf ${NDK}/toolchains/{mips64el-linux-android-4.9,mipsel-linux-android-4.9}
-# create fake dir to keep gradle from complaining
-# see https://github.com/koreader/virdevenv/pull/40
-mkdir -p ${NDK}/toolchains/mips64el-linux-android/prebuilt/linux-x86_64
+NDK=android-ndk-r23c
+
+# Hardlink duplicates (reduce size by about ~700MB).
+hardlink ${NDK}
 
 echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >>~/.bashrc
-echo 'export NDK=/home/ko/android-ndk-r15c' >>./.bashrc
+echo "export ANDROID_NDK_HOME=/home/ko/${NDK}" >>./.bashrc
 echo 'export ANDROID_HOME=/home/ko/android-sdk-linux' >>~/.bashrc
 # shellcheck disable=SC2016
 echo 'export PATH=$NDK:$ANDROID_HOME/tools/bin:$ANDROID_HOME/tools:$PATH' >>~/.bashrc

--- a/docker/ubuntu/koandroid/fetch_android_tc.sh
+++ b/docker/ubuntu/koandroid/fetch_android_tc.sh
@@ -3,5 +3,9 @@ set -e
 
 echo "Downloading NDK..."
 wget https://raw.githubusercontent.com/koreader/koreader-base/d21a0b680832c911675daf035130a0e190e5d386/toolchain/Makefile
-echo -e "y" | make android-ndk android-sdk
+make \
+  NDK_DIR='android-ndk-r23c' \
+  NDK_SUM='e5053c126a47e84726d9f7173a04686a71f9a67a' \
+  NDK_TARBALL='$(NDK_DIR)-linux.zip' \
+  android-ndk android-sdk
 rm Makefile


### PR DESCRIPTION
Since building the Android docker image normally relies on [koreader-base/toolchain/Makefile](https://github.com/koreader/koreader-base/blob/master/toolchain/Makefile), until https://github.com/koreader/koreader-base/pull/1620 is merged, I worked around the problem by overriding a few of the Makefile's variables…

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/86)
<!-- Reviewable:end -->
