### PR TITLE
appimage: fix tags (including base image)

### DIFF
--- a/docker/ubuntu/koappimage/Dockerfile
+++ b/docker/ubuntu/koappimage/Dockerfile
@@ -1,2 +1,2 @@
 ARG REGISTRY=docker.io
-FROM $REGISTRY/koreader/kobase:0.3.1
+FROM $REGISTRY/koreader/kobase:0.3.1-20.04

--- a/docker/ubuntu/koappimage/Makefile
+++ b/docker/ubuntu/koappimage/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.4.0
+VERSION=0.4.0-20.04
 REGISTRY?=docker.io
 
 all: build


### PR DESCRIPTION
Forgot to update them…

What about the other images? The remarkable image is not used by the koreader & koreader-base CIs, but it's used on Gitlab to build the nightlies, so it should probably be updated. That leaves the debian ones, which are all still on 18.04.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/88)
<!-- Reviewable:end -->
