### PR TITLE
appimage: install missing `libsndio7.0` package

### DIFF
--- a/docker/ubuntu/koappimage/Dockerfile
+++ b/docker/ubuntu/koappimage/Dockerfile
@@ -1,2 +1,13 @@
 ARG REGISTRY=docker.io
-FROM $REGISTRY/koreader/kobase:0.3.1-20.04
+FROM scratch AS base
+
+FROM $REGISTRY/koreader/kobase:0.3.1-20.04 AS build
+
+RUN sudo apt-get update
+RUN sudo apt-get upgrade -y
+RUN sudo apt-get install -y --no-install-recommends libsndio7.0
+RUN sudo apt-get clean
+RUN sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+FROM base
+COPY --from=build / /

--- a/docker/ubuntu/koappimage/Makefile
+++ b/docker/ubuntu/koappimage/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.4.0-20.04
+VERSION=0.4.1-20.04
 REGISTRY?=docker.io
 
 all: build


### PR DESCRIPTION
The sndio library is required for creating the appimage.