### PR TITLE
make baseimage usable as root

### DIFF
--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -87,43 +87,65 @@ RUN sudo make install
 WORKDIR ..
 RUN rm -rf luarocks-${LUAROCKS_VERSION}*
 # Configure.
-RUN mkdir -p ~/.luarocks
-RUN tee -a ~/.luarocks/config-5.1.lua <<EOF
-local_by_default = true
+RUN sudo tee -a /usr/local/etc/luarocks/config-5.1.lua <<\EOF
 wrap_bin_scripts = false
 EOF
 
 # lfs
-RUN luarocks install luafilesystem
+RUN sudo luarocks install luafilesystem
 
 # busted
-RUN luarocks install busted
+RUN sudo luarocks install busted
 
 # luasec.
 RUN sudo apt-get install -y --no-install-recommends libssl-dev
 # luasec doesn't automatically detect 64-bit libs
-RUN luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu
+RUN sudo luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu
 RUN sudo apt-get remove -y --auto-remove libssl-dev
 
 # luacheck
-RUN luarocks install luacheck
-RUN eval "$(luarocks path)" && sed -i 's/ lua$/ luajit/' $(which luacheck)
+RUN sudo luarocks install luacheck
+RUN sudo sed -i 's/ lua$/ luajit/' $(which luacheck)
 
 # lanes (for parallel luacheck)
-RUN luarocks install lanes
+ARG LANES_VER=3.17.0
+RUN sudo luarocks install lanes
+RUN wget https://github.com/LuaLanes/lanes/archive/refs/tags/v${LANES_VER}.tar.gz
+RUN tar -xf v${LANES_VER}.tar.gz
+RUN rm v${LANES_VER}.tar.gz
+WORKDIR lanes-${LANES_VER}
+# Remove `pthread_create` root specific setting (unsupported in docker).
+RUN patch -p1 <<\EOF
+diff --git a/src/threading.c b/src/threading.c
+index 2464d03..44357cb 100644
+--- a/src/threading.c
++++ b/src/threading.c
+@@ -810,7 +810,7 @@ void THREAD_CREATE( THREAD_T* ref, THREAD_RETURN_T (*func)( void*), void* data,
+     PT_CALL( pthread_attr_setstacksize( &a, _THREAD_STACK_SIZE));
+ #endif
+
+-    if (change_priority)
++    if (0)
+     {
+         struct sched_param sp;
+         // "The specified scheduling parameters are only used if the scheduling
+EOF
+RUN sudo luarocks make lanes-${LANES_VER}-0.rockspec
 # Ensure lanes module is detected by luacheck.
-RUN eval "$(luarocks path)" && luacheck --version | grep "^LuaLanes: ${LANES_VERSION}"
+RUN luacheck --version | grep "^LuaLanes: ${LANES_VERSION}"
+WORKDIR ..
+RUN sudo rm -rf lanes-${LANES_VER}
 
 # ldoc
-RUN luarocks install ldoc
+RUN sudo luarocks install ldoc
 
 # luacov
-RUN luarocks install luacov
+RUN sudo luarocks install luacov
 RUN wget https://github.com/moteus/luacov-coveralls/archive/refs/heads/master.zip
 RUN unzip master.zip
 RUN rm master.zip
 WORKDIR luacov-coveralls-master
-RUN luarocks make rockspecs/luacov-coveralls-scm-0.rockspec
+RUN sudo luarocks make rockspecs/luacov-coveralls-scm-0.rockspec
 WORKDIR ..
 RUN rm -rf luacov-coveralls-master
 
@@ -177,7 +199,14 @@ RUN sudo ln -sf /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 /usr/lib/x86_64-linux
 # Cleanup.
 RUN rm -vrf ~/.cache
 RUN sudo apt-get clean
-RUN sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN sudo rm -rf \
+    /tmp/* \
+    /usr/local/lib/luarocks/rocks-5.1/*/*/docs \
+    /var/cache/debconf/*-old \
+    /var/cache/luarocks \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
+    ;
 
 # Final image.
 FROM base

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -37,7 +37,8 @@ USER ko
 # compile custom xgettext with newline patch, cf. https://github.com/koreader/koreader/pull/5238#issuecomment-523794831
 # upstream bug https://savannah.gnu.org/bugs/index.php?56794
 ARG GETTEXT_VER=0.21
-RUN wget http://ftpmirror.gnu.org/gettext/gettext-${GETTEXT_VER}.tar.gz
+RUN wget http://ftpmirror.gnu.org/gettext/gettext-${GETTEXT_VER}.tar.gz \
+    || wget http://ftp.gnu.org/pub/gnu/gettext/gettext-${GETTEXT_VER}.tar.gz
 RUN tar -xf gettext-${GETTEXT_VER}.tar.gz
 WORKDIR gettext-${GETTEXT_VER}
 RUN ./configure --disable-dependency-tracking --disable-shared --disable-static

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -202,6 +202,9 @@ RUN sudo apt-get clean
 RUN sudo rm -rf \
     /tmp/* \
     /usr/local/lib/luarocks/rocks-5.1/*/*/docs \
+    /usr/share/cmake-*/Help \
+    /usr/share/doc \
+    /usr/share/nvim/runtime/doc \
     /var/cache/debconf/*-old \
     /var/cache/luarocks \
     /var/lib/apt/lists/* \

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -97,7 +97,6 @@ EOF
 RUN luarocks install luafilesystem
 
 # busted
-RUN luarocks install ansicolors
 RUN luarocks install busted
 
 # luasec.

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get install --no-install-recommends -y \
     wget \
     ;
 
+# Setup root user.
+COPY bashrc /root/.bashrc
+
 # Add dedicated user.
 RUN useradd -m ko -s /bin/bash
 RUN usermod -aG sudo ko

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -133,8 +133,6 @@ RUN rm -rf luacov-coveralls-master
 # }}}
 
 # Other development dependencies / tools.
-# NOTE: libtool-bin is due to a libzmq issue, see https://github.com/zeromq/libzmq/pull/1497
-# (can be removed if libzmq is bumped or the build switched from autotools to cmake).
 ARG MISC_TOOLS="\
     autoconf2.64 \
     automake \
@@ -147,7 +145,6 @@ ARG MISC_TOOLS="\
     fakeroot \
     hardlink \
     libtool \
-    libtool-bin \
     nasm \
     ninja-build \
     openssh-client \

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -30,8 +30,6 @@ RUN echo 'ko ALL=(ALL:ALL) NOPASSWD:ALL' | EDITOR='tee -a' visudo
 WORKDIR /home/ko
 COPY --chown=ko bashrc .bashrc
 USER ko
-RUN mkdir -p local/bin
-ENV PATH=/home/ko/local/bin:$PATH
 
 # compile custom xgettext with newline patch, cf. https://github.com/koreader/koreader/pull/5238#issuecomment-523794831
 # upstream bug https://savannah.gnu.org/bugs/index.php?56794

--- a/docker/ubuntu/baseimage-20.04/bashrc
+++ b/docker/ubuntu/baseimage-20.04/bashrc
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-HOME=/home/ko
-
 # shellcheck source=/dev/null
 . /etc/bash_completion
 
-XTOOLS=${HOME}/x-tools
+XTOOLS=/usr/local/x-tools
 
 for tc in "${XTOOLS}"/*/bin; do
     export PATH=$tc:$PATH

--- a/docker/ubuntu/baseimage-20.04/bashrc
+++ b/docker/ubuntu/baseimage-20.04/bashrc
@@ -5,9 +5,6 @@ HOME=/home/ko
 # shellcheck source=/dev/null
 . /etc/bash_completion
 
-# add local rocks to $PATH
-eval "$(luarocks path)"
-
 XTOOLS=${HOME}/x-tools
 
 for tc in "${XTOOLS}"/*/bin; do

--- a/docker/ubuntu/koandroid/Dockerfile
+++ b/docker/ubuntu/koandroid/Dockerfile
@@ -8,15 +8,15 @@ RUN wget https://github.com/koreader/koreader-base/raw/b80105edceba77e28242e1311
 
 # Install NDK.
 ARG NDK NDK_SUM
-RUN make NDK_DIR="$NDK" NDK_SUM="$NDK_SUM" android-ndk
-# And trim it.
-RUN hardlink "$NDK"
+RUN sudo make -C /opt -f "$PWD/Makefile" TOOLCHAIN_DIR=/opt \
+  NDK_DIR="$NDK" NDK_SUM="$NDK_SUM" android-ndk
 
 # Install SDK.
 ARG JDK
 RUN sudo apt-get -qq install --no-install-recommends openjdk-$JDK-jdk-headless
 ARG SDK SDK_SUM
-RUN make SDK_SUM="$SDK_SUM" SDK_TARBALL="commandlinetools-linux-$SDK.zip" android-sdk
+RUN sudo make -C /opt -f "$PWD/Makefile" TOOLCHAIN_DIR=/opt \
+  SDK_SUM="$SDK_SUM" SDK_TARBALL="commandlinetools-linux-$SDK.zip" android-sdk
 
 # Cleanup.
 RUN rm -vrf ~/.android/cache
@@ -28,10 +28,10 @@ COPY --from=build / /
 
 # Setup shell environment.
 ARG JDK NDK
-RUN tee -a .bashrc <<EOF
+RUN sudo tee -a ~ko/.bashrc /root/.bashrc <<EOF
 export JAVA_HOME='/usr/lib/jvm/java-$JDK-openjdk-amd64'
-export ANDROID_NDK_HOME='/home/ko/$NDK'
-export ANDROID_HOME='/home/ko/android-sdk-linux'
+export ANDROID_NDK_HOME='/opt/$NDK'
+export ANDROID_HOME='/opt/android-sdk-linux'
 export PATH="\$ANDROID_HOME/build-tools/30.0.2:\$PATH"
 export PATH="\$ANDROID_HOME/cmdline-tools/latest/bin:\$PATH"
 export PATH="\$ANDROID_HOME/platform-tools:\$PATH"

--- a/docker/ubuntu/scripts/install_x-tools.sh
+++ b/docker/ubuntu/scripts/install_x-tools.sh
@@ -14,11 +14,12 @@ shift 2
 echo "installing x-tools: $platform $version"
 
 wget --progress=dot:giga "https://github.com/koreader/koxtoolchain/releases/download/$version/$platform.zip"
-unzip -p "$platform.zip" | tar xzv
+unzip -p "$platform.zip" | sudo tar xzv -C /usr/local
 rm "$platform.zip"
-chmod +w -R x-tools/*/
-rm -vf x-tools/*/build.log.bz2
-hardlink x-tools/
-chmod -w -R x-tools/*/
+cd /usr/local
+sudo chmod +w -R x-tools/*/
+sudo rm -vf x-tools/*/build.log.bz2
+sudo hardlink x-tools/
+sudo chmod -w,og=rX -R x-tools/*/
 
 # vim: sw=4


### PR DESCRIPTION
Rational: makes mounting volumes much nicer, as there's no need to faff around with permissions: `docker run --user root -ti --rm -v $PWD:/src …`. Incidentally, also make the image usable on Github Actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/97)
<!-- Reviewable:end -->
