### PR TITLE
Fix: Add missing dot in Docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CMD x11vnc -forever -usepw -create -shared
 ```
 Build the docker image:
 ```
-docker build -f <custom_docker_file> -t vnckoappimage
+docker build -f <custom_docker_file> -t vnckoappimage .
 ```
 Using the modified docker image above, you can then run it headlessly, like so:
 ```


### PR DESCRIPTION
It wasn't immediately clear to me what was causing the issue. Adding the dot makes it more explicit for beginners. This gives them a simple, ready-to-use command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/103)
<!-- Reviewable:end -->
