### PR TITLE
baseimage-20.04: ffi-cdecl support

### DIFF
--- a/docker/ubuntu/Makefile
+++ b/docker/ubuntu/Makefile
@@ -3,7 +3,7 @@
 
 BUILDER ?= docker
 REGISTRY ?= docker.io
-BASEIMAGE ?= koreader/kobase:0.3.4-20.04
+BASEIMAGE ?= koreader/kobase:0.3.5-20.04
 X_TOOLS_VERSION ?= 2025.01
 
 IMAGES = $(patsubst %/,%,$(dir $(wildcard */Dockerfile)))

--- a/docker/ubuntu/baseimage-20.04/Dockerfile
+++ b/docker/ubuntu/baseimage-20.04/Dockerfile
@@ -141,6 +141,7 @@ RUN rm -rf luacov-coveralls-master
 
 # NOTE: SDL2 is also needed for the tests.
 ARG APPIMAGE_DEPS="libsdl2-2.0-0"
+ARG FFI_CDECL_DEPS="gcc-9-plugin-dev"
 # GLib meson build needs distutils.
 ARG GLIB_DEPS="python3-distutils"
 # NOTE: we don't install `gcc-multilib`, as it conflicts with cross-toolchains.
@@ -163,13 +164,14 @@ ARG MISC_TOOLS="\
     openssh-client \
     p7zip-full \
     patch \
-    pkg-config \
+    pkgconf \
     python3 \
     python3-pip \
     zip \
     "
 RUN sudo --preserve-env=DEBIAN_FRONTEND apt-get install --no-install-recommends -y \
     $APPIMAGE_DEPS \
+    $FFI_CDECL_DEPS \
     $GLIB_DEPS \
     $LUAJIT_DEPS \
     $MISC_TOOLS \

--- a/docker/ubuntu/baseimage-20.04/settings.mk
+++ b/docker/ubuntu/baseimage-20.04/settings.mk
@@ -1,3 +1,3 @@
 IMAGE = kobase
-VERSION = 0.3.4-20.04
+VERSION = 0.3.5-20.04
 BASE = ubuntu:focal


### PR DESCRIPTION
- switch to pkgconf (from pkg-config, for `--env-only` support)
- install GCC plugin development package

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/112)
<!-- Reviewable:end -->
