### PR TITLE
nightswatcher: downgrade gevent version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     python-packages:
       patterns:
         - "*"
+      exclude-patterns:
+        - "gevent"

--- a/docker/ubuntu/nightswatcher/requirements.txt
+++ b/docker/ubuntu/nightswatcher/requirements.txt
@@ -1,5 +1,5 @@
 falcon==4.2.0
-gevent==26.4.0
+gevent==25.9.1
 gunicorn==25.3.0
 requests==2.33.1
 ujson==5.12.0


### PR DESCRIPTION
Version 26.4.0 does not have wheels for Python 3.10 / AArch64.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/virdevenv/155)
<!-- Reviewable:end -->
